### PR TITLE
R&c switch

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,11 +68,12 @@ function preFill() {
     case 'SD':
       applName.value = 'SD-22-';
       applName.setAttribute('placeholder', 'SD-')
+      disposal.value = 'R&C'
       break;
     case 'LOR':
       applName.value = 'LOR-22-';
       applName.setAttribute('placeholder', 'LOR-')
-      // applName.setAttribute('type', 'number');
+      disposal.value = 'R&C'
       break;
     case 'N/A':
       applName.value = '';

--- a/app.js
+++ b/app.js
@@ -94,7 +94,7 @@ submit.addEventListener('click', (e) => {
 
 
   if (itmType === 'Type' || applName === '') {
-    ;
+    alert('Please enter an item type and applicant name');
     return;
   }
 
@@ -225,6 +225,8 @@ document.querySelector('#print').addEventListener('click', () => {
     if (dispCell[i].textContent === 'PENDING') {
       dispCell[i].classList.add('highlight');
       return;
+    } else {
+      dispCell[i].classList.remove('highlight');
     }
   }
   // if no dispCell is "PENDING", print page

--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
     content="A mobile-friendly, offline-capable tool for recording and submitting City of Atlanta NPU Voting reports.">
   <meta property="og:type" content=website>
   <meta property="og:image" content=https://urbaned0ge.github.io/VotingForm/NPU%20Logo%20Black-10.png>
+  <!-- disable google translate -->
+  <meta name="google" content="notranslate">
   <!-- Bootstrap CSS only -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
@@ -104,7 +106,7 @@
         <option value='LOR'>LOR</option>
         <option value='N/A'>Other...</option>
       </select>
-      <input type="text" name="applName" id="applName" placeholder='Application number or name' required>
+      <input type="text" name="applName" id="applName" placeholder='Application number or name' required />
       <select name='disposal' id='disposal'>
         <option value='PENDING' hidden selected disabled>Recommend</option>
         <option value='Approval'>Approval</option>
@@ -116,7 +118,7 @@
       </select>
       <textarea class='comments' name="conditions" id="conditions" cols="30" rows="2"
         placeholder='Comments / Conditions...'></textarea>
-      <button id='submit' value='submit' class='mt-1'>Submit</button>
+      <button id='submit' value='submit' type='submit' class='mt-1'>Submit</button>
     </form>
     </legend>
   </div>
@@ -204,8 +206,7 @@
     <p>Prepared by the <a href='https://www.atlantaga.gov/government/departments/city-planning'
         target='_blank'>Department of City
         Planning</a>, City of Atlanta | Send questions and bug reports to <a
-        href="mailto:kdunlap@atlantaga.gov">KDunlap@AtlantaGA.gov</a></p>
-
+        href="mailto:kdunlap@atlantaga.gov">KDunlap@AtlantaGA.gov</a> | Version 1.3</p>
   </footer>
   <script src="app.js" async defer></script>
   <script type='module'>

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
         <option value='Denial'>Denial</option>
         <option value='Defer'>Defer</option>
         <option value='Abstain'>Abstain</option>
-        <!-- <option value='R&C'>Review & Comment</option> -->
+        <option value='R&C'>Review & Comment</option>
       </select>
       <textarea class='comments' name="conditions" id="conditions" cols="30" rows="2"
         placeholder='Comments / Conditions...'></textarea>

--- a/style.css
+++ b/style.css
@@ -67,6 +67,9 @@ table {
 
 tbody:nth-child(odd) {
   background-color: lightgrey;
+  -webkit-print-color-adjust: exact !important;
+  color-adjust: exact !important;
+  print-color-adjust: exact !important;
 }
 
 /* thead > tr {
@@ -206,6 +209,15 @@ and (max-width : 425px) {
   #newItem {
     visibility: hidden;
     display: none;
+  }
+  #signature {
+  -webkit-print-color-adjust: exact !important;
+  color-adjust: exact !important;
+  print-color-adjust: exact !important;
+  }
+  body {
+    margin-left: .75in;
+    margin-right: .75in;
   }
 }
 


### PR DESCRIPTION
Using media queries, adjust the print margins and enforce background graphics (box shading) even when turned off.

Re-check that pending items have been filled, and remove the alert-highlighting when outcomes are chosen.

Attach version number to page to better track when users are using up-to-date versions.