### PR TITLE
Notes to native

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,7 +110,7 @@ submit.addEventListener('click', (e) => {
   itmTypeCell.innerText = itmType;
   itmTypeCell.prepend(deleteButton);
   deleteButton.setAttribute('type', 'button');
-  deleteButton.setAttribute('class', 'btn-close');
+  deleteButton.setAttribute('class', 'btn-close my-1');
   applNameCell.textContent = applName;
   applNameCell.setAttribute('contenteditable', 'true');
   applNameCell.classList.add('applName');
@@ -244,8 +244,8 @@ let field = document.querySelector('#date');
 
 // listen for print event
 window.addEventListener('beforeprint', () => {
-  NPU = document.getElementById('NPU').value;
-
+  let NPU = document.getElementById('NPU').value;
+  let notes = document.getElementById('pNotes').value;
   // Get the date
   let date = new Date(`${field.value}T00:00:00`);
   // Format date as MM-DD-YYYY
@@ -273,8 +273,9 @@ window.addEventListener('beforeprint', () => {
   // remove all highlight classes
   document.querySelectorAll('.highlight').forEach(cell => {
     cell.classList.remove('highlight');
-  }
-  );
+  });
+  // change pNotes textarea to <h5> element
+  document.querySelector('#pNotes').outerHTML = `<h5 id="pNotes">${notes}</h5>`;
 });
 
 // reset title after print
@@ -288,4 +289,6 @@ window.addEventListener('afterprint', () => {
     btn.style.display = 'inline';
   });
   document.getElementById('signature').style.display = 'none';
+  let notes = document.getElementById('pNotes').textContent;
+  document.querySelector('#pNotes').outerHTML = `<textarea id="pNotes" class="form-control" placeholder="Enter any notes here...">${notes}</textarea>`;
 });

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
     <p>Prepared by the <a href='https://www.atlantaga.gov/government/departments/city-planning'
         target='_blank'>Department of City
         Planning</a>, City of Atlanta | Send questions and bug reports to <a
-        href="mailto:kdunlap@atlantaga.gov">KDunlap@AtlantaGA.gov</a> | Version 1.3</p>
+        href="mailto:kdunlap@atlantaga.gov">KDunlap@AtlantaGA.gov</a> | Version 1.4</p>
   </footer>
   <script src="app.js" async defer></script>
   <script type='module'>

--- a/index.html
+++ b/index.html
@@ -216,8 +216,6 @@
           {
             scope: new URL('', import.meta.url).pathname,
             type: 'module'
-          }).then(function (registration) {
-            console.log('Service worker registered: ', registration);
           });
       } catch (error) {
         console.log('Service Worker Registration Failed: ', error);

--- a/style.css
+++ b/style.css
@@ -162,7 +162,8 @@ ol {
 
 #pNotes {
   width: 100%;
-  background-color: whitesmoke;
+  /* background-color: whitesmoke; */
+  white-space: pre-wrap;
 }
 
 #print {
@@ -218,6 +219,8 @@ and (max-width : 425px) {
   body {
     margin-left: .75in;
     margin-right: .75in;
+    filter: grayscale(100%);
+    -webkit-filter: grayscale(100%);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -68,7 +68,7 @@ table {
 tbody:nth-child(odd) {
   background-color: lightgrey;
   -webkit-print-color-adjust: exact !important;
-  color-adjust: exact !important;
+  /* color-adjust: exact !important; */
   print-color-adjust: exact !important;
 }
 
@@ -213,7 +213,7 @@ and (max-width : 425px) {
   }
   #signature {
   -webkit-print-color-adjust: exact !important;
-  color-adjust: exact !important;
+  /* color-adjust: exact !important; */
   print-color-adjust: exact !important;
   }
   body {


### PR DESCRIPTION
On print, Planner's notes section becomes an <h5> element which cannot be cut off during printing. CSS styling has been applied to preserve whitespace.

CSS rules have also been applied to transform the page to grayscale, saving ink and resulting in a more document-like page.

This version has been designated 1.4