### PR TITLE
fix 'PENDING' items allowed to print

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,10 @@
     "colspan",
     "contenteditable",
     "MOSE"
-  ]
+  ],
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#481063",
+    "titleBar.activeBackground": "#64178B",
+    "titleBar.activeForeground": "#FEFCFF"
+  }
 }


### PR DESCRIPTION
Reconfigured the logic for applying hilight to pending items, and for preventing print.